### PR TITLE
Correct gap computation in gapbuf_inserts

### DIFF
--- a/gapbuf.c
+++ b/gapbuf.c
@@ -115,14 +115,16 @@ void
 gapbuf_inserts(struct gapbuf *b, const char *s)
 {
     size_t len = strlen(s);
+    size_t back = b->total - b->front - b->gap;
     while (b->gap < len) {
         b->gap = 0;
         gapbuf_insert(b, 0);
         b->front--;
+        b->gap++;
     }
     memcpy(b->buf + b->front, s, len);
     b->front += len;
-    b->gap -= len;
+    b->gap = b->total - b->front - back;
 }
 
 void


### PR DESCRIPTION
Given code like:

```c
struct gapbuf b;
gapbuf_init(&b, 10);
gapbuf_insert(&b, 'a');
gapbuf_insert(&b, 'b');
gapbuf_insert(&b, 'c');
gapbuf_backward(&b);
```

If we print the back size:
```c
printf("Back size: %lu\n", b.total - b.front - b.gap);
```

It evaluates to 1.

Then, if we manually insert a string with a loop and `gapbuf_insert` (it is important to note that `m` is chosen to be larger than the size of the gap, so that it triggers the grow code):

```c
const char *m = "A gap buffer is good at clustered edits.";
for (size_t i = 0; i < strlen(m); i++)
        gapbuf_insert(&b, m[i]);
```

Then print the back size again, it is also 1. So far so good.

However, when you perform the equivalent operation with `gapbuf_inserts`:

```c
gapbuf_inserts(&b, m);
```

Then back size evaluates to 79, which is clearly incorrect, it should be 1 like the equivalent operation with `gapbuf_insert`. 

From what I can tell the solution is to keep the original back size around, and then when gap is recomputed use it to determine the new gap size which preserves the original back size.

It seems like this didn't break the animator because the size of the gap is big enough such that this buggy grow code isn't triggered.
